### PR TITLE
clear favorites list control updated

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -266,7 +266,8 @@ function addFavouriteBreweryToLocalStorage() {
 //clear items from local storage
 function clearLocalStorage () {
   localStorage.clear();
-  removeOptions(listEl);
+  var listFavEl = document.getElementById("listFavourites");
+  removeOptions(listFavEl);
 }
 
 //============================


### PR DESCRIPTION
I updated the functionality of the "clear favorites" button
It was clearing the breweries list before, that was in the last "listEl" reference
Now it clears the Favorites List control (in addition to the local storage that was done by Mark)  